### PR TITLE
fix: move images to new lines

### DIFF
--- a/applications/secret_manager.md
+++ b/applications/secret_manager.md
@@ -13,15 +13,15 @@ Workspace secrets—such as API tokens, database credentials, or service keys—
 
 - **Centralized and secure storage** of credentials for all workspace users  
 - **Collaborative access**: All users within the workspace with correct roles can access and manage secrets  
-  - Key/value pairs can be added, updated and deleted.
+  - Key/value pairs can be added, updated and deleted.  
   ![credential-without-annotation.png](assets/credential-without-annotation.png)
 - **Reusability**: Secrets can be reused across different applications (e.g., JupyterLab, Argo Workflows, data pipelines)
 
 ### Readonly / Key-only credentials
 - Individual credentials can be set to **readonly** or **key-only** (has to be done by an administrator).
-- **Readonly** & **key-only** credentials can only be viewed, but not edited or deleted.
+- **Readonly** & **key-only** credentials can only be viewed, but not edited or deleted.  
 ![readonly-credential.png](assets/readonly-credential.png)
-- **Key-only** credentials only display the key, while the value is disguised.
+- **Key-only** credentials only display the key, while the value is disguised.  
 ![key-only-credential.png](assets/key-only-credential.png)
 
 


### PR DESCRIPTION
Unfortunately the github preview of the markdown files does not correspond to how it's displayed on https://documentation.hub.eox.at/.
Currently the images are shown in the same line as the text:

<img width="900" height="424" alt="image" src="https://github.com/user-attachments/assets/93babeb0-49e5-4858-a4db-13e3cc960829" />

Added empty spaces, to (hopefully) move the images to new lines.
