### PR TITLE
fix: add blank lines before & after images

### DIFF
--- a/applications/secret_manager.md
+++ b/applications/secret_manager.md
@@ -14,16 +14,20 @@ Workspace secrets—such as API tokens, database credentials, or service keys—
 - **Centralized and secure storage** of credentials for all workspace users  
 - **Collaborative access**: All users within the workspace with correct roles can access and manage secrets  
   - Key/value pairs can be added, updated and deleted.  
+  
   ![credential-without-annotation.png](assets/credential-without-annotation.png)
+
 - **Reusability**: Secrets can be reused across different applications (e.g., JupyterLab, Argo Workflows, data pipelines)
 
 ### Readonly / Key-only credentials
 - Individual credentials can be set to **readonly** or **key-only** (has to be done by an administrator).
 - **Readonly** & **key-only** credentials can only be viewed, but not edited or deleted.  
-![readonly-credential.png](assets/readonly-credential.png)
-- **Key-only** credentials only display the key, while the value is disguised.  
-![key-only-credential.png](assets/key-only-credential.png)
 
+![readonly-credential.png](assets/readonly-credential.png)
+
+- **Key-only** credentials only display the key, while the value is disguised. 
+
+![key-only-credential.png](assets/key-only-credential.png)
 
 ## Example Use Cases
 


### PR DESCRIPTION
images are still shown very tiny, although the preview is fine.. maybe adding blank lines before/after the images will work.

<img width="869" height="345" alt="image" src="https://github.com/user-attachments/assets/56143561-af90-4096-b979-94a2f1fa6fa3" />
